### PR TITLE
Specify crossScalaVersions to support Scala 2.11.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ organization := "com.thg.opensource"
 version := "0.0.2"
 
 scalaVersion := "2.12.5"
+crossScalaVersions := Seq("2.11.8", "2.12.5")
 val kamonVersion = "1.1.0"
 
 bintrayOrganization := Some("opensource-thg")


### PR DESCRIPTION
Allows us to have an artefact for both `2.12.5` & `2.11.8`

![image](https://user-images.githubusercontent.com/6763911/46868252-a0177500-ce1f-11e8-8209-edec30ebd3c1.png)

`compile` will simply compile the `2.12.5` target
`+ compile` should be used to compile the project for all versions specified in `crossScalaVersions`


